### PR TITLE
no outdated shaming

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,11 +8,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{ec684662-e26b-4308-82ea-1cdf2d3eb917}",
-      "strict_min_version": "110.0"
+      "strict_min_version": "1"
     }
   },
 
-  "minimum_chrome_version": "110",
+  "minimum_chrome_version": "1",
 
   "icons": {
     "16": "img/16x16.png",


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)